### PR TITLE
Expand date filter select box width

### DIFF
--- a/edit-post/assets/stylesheets/main.scss
+++ b/edit-post/assets/stylesheets/main.scss
@@ -73,6 +73,11 @@ body.gutenberg-editor-page {
 	ul#adminmenu>li.current>a.current:after {
 		border-right-color: $white;
 	}
+	
+	.media-frame select.attachment-filters:last-of-type {
+	    	width: auto;
+	    	max-width: 100%;
+	}
 }
 
 .gutenberg {


### PR DESCRIPTION
Widens the "All Dates" select box in the "Add Media" modal window, so that the full placeholder text is shown. Fix for #2202

## Description
Added CSS to edit-post/assets/stylesheets/main.scss

## How has this been tested?
Browser tested in Chrome 67.0.3396.99 and FF 61.0.1, Windows 10

## Screenshots
**Before changes**
![gutenberg-2202-before](https://user-images.githubusercontent.com/34601694/43480922-96146c38-94d2-11e8-808d-08d650be025c.PNG)

**After changes**
![gutenberg-2202-after](https://user-images.githubusercontent.com/34601694/43480921-95fddb6c-94d2-11e8-845f-6ed8e134f9dd.PNG)

## Checklist:
- [ X ] My code is tested.
- [ X ] My code follows the WordPress code style.
- [ X ] My code follows the accessibility standards.
- [ X ] My code has proper inline documentation.



